### PR TITLE
G3A-62 FIX: Remove Email Icon Focus and Adjust Error Message Colors

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -10,6 +10,7 @@
 
     <link rel="icon" href="{{ asset('images/officialLogo.svg') }}" type="image/svg+xml">
 
+
     <title>Forgot Password</title>
     @vite('resources/css/app.css')
 
@@ -66,9 +67,9 @@
                     <div class="mt-5 mb-2">
                         <label class="w-full rounded-full max-w-[380px] mx-auto px-4 py-3 outline bg-white flex focus-within:outline-3 focus-within:outline-[var(--secondary-color)]">
                             <input type="email" id="emailInput" name="email" placeholder="Email Address" required
-                                class="w-0 flex-grow  outline-none mr-3 text-[14px]">
-                            <button type="button">
-                                <img src="{{ asset('images/email.svg') }}" alt="Show Password" class="w-4 mr-1" />
+                                class="w-0 flex-grow outline-none mr-3 text-[14px]">
+                            <button type="button" class="focus:outline-none" tabindex="-1">
+                                <img src="{{ asset('images/email.svg') }}" alt="Email Icon" class="w-4 mr-1" />
                             </button>
                         </label>
                         <div id="emailLengthWarning" class="text-red-600 text-xs mt-2 text-center hidden">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -255,8 +255,8 @@
                         <label class="w-full rounded-2xl px-3 py-2 md:p-4 outline bg-white flex focus-within:outline-3 focus-within:outline-[var(--secondary-color)]">
                             <input type="email" id="emailInput" name="email" placeholder="Email Address" required
                                 class="w-0 flex-grow outline-none mr-3" maxlength="100">
-                            <button type="button">
-                                <img src="{{ asset('images/email.svg') }}" alt="Show Password" class="w-5 md:w-6" />
+                            <button type="button" class="focus:outline-none" tabindex="-1">
+                                <img src="{{ asset('images/email.svg') }}" alt="Email Icon" class="w-5 md:w-6" />
                             </button>
                         </label>
                         <div id="emailLengthWarning" class="text-red-500 text-sm mt-2 text-center hidden">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -259,7 +259,7 @@
                                 <img src="{{ asset('images/email.svg') }}" alt="Email Icon" class="w-5 md:w-6" />
                             </button>
                         </label>
-                        <div id="emailLengthWarning" class="text-red-500 text-sm mt-2 text-center hidden">
+                        <div id="emailLengthWarning" class="text-red-600 text-sm mt-2 text-center hidden">
                             <strong>Email must not exceed 50 characters.</strong>
                         </div>
                     </div>
@@ -285,12 +285,12 @@
 
                     <!-- Error Message -->
                     @if ($errors->any() && !$errors->has('lockout_time'))
-                    <div class="status-message text-red-500 text-sm mt-2 text-center pb-1">
+                    <div class="status-message text-red-600 text-sm mt-2 text-center pb-1">
                         <strong>{{ $errors->first() }}</strong>
                     </div>
                     @endif
                     @if ($errors->has('lockout_time'))
-                    <div class="text-red-500 text-sm mt-2 text-center pb-1">
+                    <div class="text-red-600 text-sm mt-2 text-center pb-1">
                         <strong id="lockout-message">Too many login attempts. Please try again in <span id="lockout-timer"></span> seconds.</strong>
                     </div>
                     <script>


### PR DESCRIPTION
This pull request addresses G3A-62 by removing the focus highlight on the email icon within the input field to reduce visual distraction, and refining the color of error messages on the login page for better visibility and consistency with the overall design.