### PR TITLE
CHORE: created backendpoints for update notifications

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -47,6 +47,16 @@ class NotificationController extends Controller
         return response()->json($notifications);
     }
 
+    // Mark Notification as Read
+    public function markAsRead($id)
+    {
+        $notification = Notification::findOrFail($id);
+        $notification->is_read = true;
+        $notification->save();
+
+        return response()->json(['message' => 'Notification marked as read']);
+    }
+
  
 
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\NotificationController;
 Route::post('/notifications/send', [NotificationController::class, 'send']);
 Route::get('/notifications/{userId}', [NotificationController::class, 'getAll']);
 Route::get('/notifications/{userId}/unread', [NotificationController::class, 'getUnread']);
+Route::put('/notifications/{id}/read', [NotificationController::class, 'markAsRead']);
 
 
 


### PR DESCRIPTION
This is for when the user reads the notification. The notification will be updated and marked as read, or according to the Figma, it will move under the 'All' section if it's read.

![image](https://github.com/user-attachments/assets/f1f78f82-9320-48c4-927e-a654bc3ad65e)

![image](https://github.com/user-attachments/assets/1539ca13-ac2c-41cd-8a8b-71565b579207)
