### PR TITLE
Dsm5 28 dev implement autogenerating document i ds on submit

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -35,11 +35,14 @@ class DocumentController extends Controller
                 }
             }
 
-            // Generate a unique document ID (e.g., DOC-20250505-XYZ123) (TENTATIVE, PROPER FORMAT IS NOT FOLLOWED YET)
-            $validated['control_tag'] = 'DOC-' . now()->format('Ymd') . '-' . strtoupper(Str::random(6));
+            // Save first to get the auto-increment ID
+            $document = Document::create($validated);
 
-            // Store the validated data in the database
-            Document::create($validated);
+            // Format: DOC-0001 ("DOC" IS USED FOR A MOMENT, ORGANIZATION NAME OF USER IS NOT YET INCLUDED IN THE FORMAT)
+            $document->control_tag = 'DOC-' . str_pad($document->id, 4, '0', STR_PAD_LEFT);
+
+            // Store the validated data in the database.
+            $document->save();
 
             return back()->with('success', 'Document submitted successfully!');
         } catch (\Illuminate\Validation\ValidationException $e) {

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Document;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class DocumentController extends Controller
 {
@@ -33,6 +34,9 @@ class DocumentController extends Controller
                     return back()->withErrors(['file_upload' => 'Failed to upload file. Please try again.']);
                 }
             }
+
+            // Generate a unique document ID (e.g., DOC-20250505-XYZ123) (TENTATIVE, PROPER FORMAT IS NOT FOLLOWED YET)
+            $validated['control_tag'] = 'DOC-' . now()->format('Ymd') . '-' . strtoupper(Str::random(6));
 
             // Store the validated data in the database
             Document::create($validated);

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -12,6 +12,7 @@ class Document extends Model
         'doc_receiver',
         'subject',
         'doc_type',
+        'control_tag',
         'summary',
         'event_start_date',
         'event_end_date',

--- a/database/migrations/2025_05_03_031958_create_submitted_documents_table.php
+++ b/database/migrations/2025_05_03_031958_create_submitted_documents_table.php
@@ -13,10 +13,10 @@ return new class extends Migration
     {
         Schema::create('submitted_documents', function (Blueprint $table) {
             $table->id();
+            $table->string('control_tag')->unique()->default('AUTO');
             $table->string('doc_receiver');
             $table->string('subject');
             $table->string('doc_type');
-            $table->string('control_tag')->unique();
             $table->text('summary')->nullable();
             $table->date('eventStartDate')->nullable();
             $table->date('eventEndDate')->nullable();

--- a/database/migrations/2025_05_03_031958_create_submitted_documents_table.php
+++ b/database/migrations/2025_05_03_031958_create_submitted_documents_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->string('doc_receiver');
             $table->string('subject');
             $table->string('doc_type');
+            $table->string('control_tag')->unique();
             $table->text('summary')->nullable();
             $table->date('eventStartDate')->nullable();
             $table->date('eventEndDate')->nullable();


### PR DESCRIPTION
This task involves automatically creating a unique Document ID each time a user submits a form or uploads a file. The Document ID serves as a reference number that helps in tracking, organizing, and retrieving documents efficiently within the system.

Note: The field/column name of the Document ID in the database is called "control_tag". Also, the naming format of the Document ID doesn't use the organization name of the user yet, and instead use "DOC". Code will be changed when issues regarding account creation are fixed. Current format is DOC-0001.