### PR TITLE
G3A-117 FIX: Account "Active" Status Validation to Forgot Password

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -30,6 +30,7 @@ class PasswordResetLinkController extends Controller
 
         // Check if the email exists in the users table and matches the role
         $user = User::where('email', $request->email)
+            ->where('active', 1) // Ensure the user is active
             ->where(function ($query) use ($role) {
                 if ($role === 'student') {
                     $query->where('role', 'student');


### PR DESCRIPTION
Enhance the forgot password functionality to verify the Active status of the user before sending a password reset email. If the account associated with the provided email is deactivated, the reset email should not be sent