### PR TITLE
G3A-58 CHORE: Seed default super admin user into database

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,27 +17,11 @@ class DatabaseSeeder extends Seeder
     {
         User::create([
             'username' => 'SuperAdmintUser',
-            'email' => 'superadmin@example.com',
-            'password' => Hash::make('superadminpass'),
+            'email' => 'superadmin@gmail.com',
+            'password' => Hash::make('@Eskolarian12345'),
             'role' => 'super admin',
             'profile_pic' => 'images/profiles/student.png', // Example value
 
-        ]);
-
-        User::create([
-            'username' => 'AdminUser',
-            'email' => 'admin@example.com',
-            'password' => Hash::make('adminpass'),
-            'role' => 'admin',
-            'profile_pic' => 'images/profiles/student.png', // Example value
-        ]);
-
-        User::create([
-            'username' => 'StudentUser',
-            'email' => 'student@example.com',
-            'password' => Hash::make('studentpass'),
-            'role' => 'student',
-            'profile_pic' => 'images/profiles/student.png', // Example value
         ]);
     }
 


### PR DESCRIPTION
Created a default super admin account via DatabaseSeeder to serve as the super administrator for the system.
- Email: superadmin@gmail.com
- Password: @Eskolarian12345

This account will be used to manage other users from the Super Admin Dashboard.

Changes
- Added seeding logic for the official super admin account.
- Removed pre-made student and admin seed accounts, as those can now be created directly via the Super Admin interface.

Setup Steps

- Manually delete all existing user records in your users table.
- Run the seeder: php artisan db:seed
- Rebuild frontend assets: npm run dev
- Start the Laravel server: php artisan serve