### PR TITLE
G3A-122 FIX: Remove the default eye icon in Edge browser

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,6 +8,11 @@
     <link rel="icon" href="{{ asset('images/officialLogo.svg') }}" type="image/svg+xml">
 
     <title>E-skolarian</title>
+    <style>
+        input[type="password"]::-ms-reveal {
+            display: none;
+        }
+    </style>
 
     @vite('resources/css/app.css')
 

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -14,6 +14,11 @@ if ($role === 'super admin') {
     <link rel="icon" href="{{ asset('images/officialLogo.svg') }}" type="image/svg+xml">
 
     <title>Reset Password</title>
+    <style>
+        input[type="password"]::-ms-reveal {
+            display: none;
+        }
+    </style>
     @vite('resources/css/app.css')
 
     <script>


### PR DESCRIPTION
This fix addresses the issue G3A-122 where the Edge browser displays a default eye icon in password input fields. The change ensures a cleaner and more consistent user interface across all browsers by removing the browser-specific icon