### PR TITLE
G3A-128 FIX: Restricts access to other role pages and prevents back navigation to the login page after login 

### DIFF
--- a/app/Http/Middleware/IsAdmin.php
+++ b/app/Http/Middleware/IsAdmin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class IsAdmin
+{
+    public function handle($request, Closure $next)
+    {
+        if (Auth::check() && Auth::user()->role === 'admin') {
+            return $next($request);
+        }
+
+        abort(403, 'Unauthorized access.');
+    }
+}

--- a/app/Http/Middleware/IsStudent.php
+++ b/app/Http/Middleware/IsStudent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class IsStudent
+{
+    public function handle($request, Closure $next)
+    {
+        if (Auth::check() && Auth::user()->role === 'student') {
+            return $next($request);
+        }
+
+        abort(403, 'Unauthorized access.');
+    }
+}

--- a/app/Http/Middleware/IsSuperAdmin.php
+++ b/app/Http/Middleware/IsSuperAdmin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class IsSuperAdmin
+{
+    public function handle($request, Closure $next)
+    {
+        if (Auth::check() && Auth::user()->role === 'super admin') {
+            return $next($request);
+        }
+
+        abort(403, 'Unauthorized access.');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,19 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->redirectTo(
+            guests: '/login',
+            users: function ($request) {
+                $user = $request->user();
+
+                return match ($user->role) {
+                    'super admin' => '/super-admin/dashboard',
+                    'admin' => '/admin/dashboard',
+                    'student' => '/student/dashboard',
+                    default => '/login',
+                };
+            }
+        );
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,7 @@ Route::get('/notification', function () {
 
     });
     Route::middleware(['auth', NoBackHistory::class, IsAdmin::class])->group(function () {
+        // ---------------- Admin ----------------
         Route::get('/admin/dashboard', fn () => view('admin.dashboard'))->name('admin.dashboard');
         Route::get('/admin/settings', [SettingsController::class, 'viewAdminSettings'])->name('admin.settings');
         Route::get('/admin/documentReview', [DocumentReviewController::class, 'index'])->name('admin.documentReview');

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,9 +21,27 @@ use App\Http\Controllers\IndexTwoController;
 Route::get('/', function () {
     return redirect()->route('login');
 });
-Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
-Route::post('/login', [LoginController::class, 'login']);
-Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
+
+Route::middleware('guest')->group(function () {
+    Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
+    Route::post('/login', [LoginController::class, 'login']);
+
+    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])->name('password.request');
+    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])->name('password.email');
+    Route::get('reset-password/{token}', [PasswordResetLinkController::class, 'edit'])->name('password.reset');
+    Route::post('reset-password', [PasswordResetLinkController::class, 'update'])->name('password.update');
+
+    Route::get('password-reset-confirmation', function () {
+        return view('auth.password-reset-confirmation');
+    })->name('password.reset.confirmation');
+
+    /* Temporary Route for Email Template */
+    Route::get('/custom-reset-password', function () {
+        return view('emails.custom-reset-password');
+
+    });
+});
+
 Route::get('/notification', function () {
     return view('components.general-components.notification');
 });
@@ -95,7 +113,9 @@ Route::middleware(['auth', NoBackHistory::class])->group(function () {
         return view('student.documentArchive');
     })->name('student.documentArchive');
     // Route for the document preview page (admin)
-Route::get('/document/preview/{id}', [AdminDocumentController::class, 'preview'])->name('admin.documentPreview');
+    Route::get('/document/preview/{id}', [AdminDocumentController::class, 'preview'])->name('admin.documentPreview');
+
+    Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 });
 
 // Fetching and displaying and storing comments
@@ -126,20 +146,6 @@ Route::get('/notifications', function () {
     return view('notifications');
 })->name('notifications');
 
-Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])->name('password.request');
-Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])->name('password.email');
-Route::get('reset-password/{token}', [PasswordResetLinkController::class, 'edit'])->name('password.reset');
-Route::post('reset-password', [PasswordResetLinkController::class, 'update'])->name('password.update');
-
-Route::get('password-reset-confirmation', function () {
-    return view('auth.password-reset-confirmation');
-})->name('password.reset.confirmation');
-
-/* Temporary Route for Email Template */
-Route::get('/custom-reset-password', function () {
-    return view('emails.custom-reset-password');
-
-});
 
 // CHANGE THIS //
 // Route::get('/', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,12 @@ use App\Http\Controllers\StudentTrackerController;
 use App\Http\Controllers\DocumentReviewController;
 use App\Http\Middleware\NoBackHistory;
 use App\Http\Controllers\SettingsController;
+use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\IndexTwoController;
+use App\Http\Middleware\IsSuperAdmin;
+use App\Http\Middleware\IsAdmin;
+use App\Http\Middleware\IsStudent;
+
 
 
 Route::get('/', function () {
@@ -48,154 +53,109 @@ Route::get('/notification', function () {
 
 
 
-Route::middleware(['auth', NoBackHistory::class])->group(function () {
-    Route::get('/student/dashboard', fn () => view('student.dashboard')) -> name('student.dashboard');
-    Route::get('/admin/dashboard', fn () => view('admin.dashboard')) -> name('admin.dashboard');
+// ----------------------------------------
+// Authenticated Routes
+// ----------------------------------------
+    Route::middleware(['auth', NoBackHistory::class, IsSuperAdmin::class])->group(function () {
+        // ---------------- Super Admin ----------------
+        Route::get('/super-admin/dashboard', [SuperAdminController::class, 'showDashboard'])->name('super-admin.dashboard');
+        Route::get('/super-admin/deactivated-accounts', [UserController::class, 'deactivatedUsers'])->name('deactivated.accounts');
+        Route::post('/super-admin/deactivate-user', [SuperAdminController::class, 'deactivateUser'])->name('super-admin.deactivate-user');
+        Route::post('/super-admin/reactivate-user/{user}', [UserController::class, 'reactivateUser'])->name('reactivate.user');
 
-    // Calendar routes
+    });
+    Route::middleware(['auth', NoBackHistory::class, IsAdmin::class])->group(function () {
+        Route::get('/admin/dashboard', fn () => view('admin.dashboard'))->name('admin.dashboard');
+        Route::get('/admin/settings', [SettingsController::class, 'viewAdminSettings'])->name('admin.settings');
+        Route::get('/admin/documentReview', [DocumentReviewController::class, 'index'])->name('admin.documentReview');
+        Route::get('/admin/review', fn () => view('admin.review'))->name('admin.review');
+        Route::get('/admin/documentArchive', fn () => view('admin.documentArchive'))->name('admin.documentArchive');
+        Route::get('/document/preview/{id}', [AdminDocumentController::class, 'preview'])->name('admin.documentPreview');
+
+        // Document processing
+        Route::get('/admin/documents', [DocumentReviewController::class, 'index'])->name('admin.documents');
+        Route::get('/admin/documents/{id}/details', [DocumentReviewController::class, 'getDetails'])->name('admin.documents.details');
+        Route::post('/admin/documents/{id}/mark-as-opened', [DocumentReviewController::class, 'markAsOpened'])->name('admin.documents.mark-as-opened');
+        Route::post('/admin/documents/{id}/approve', [DocumentReviewController::class, 'approveDocument'])->name('admin.documents.approve');
+        Route::post('/admin/documents/{id}/forward', [DocumentReviewController::class, 'forwardDocument'])->name('admin.documents.forward');
+        Route::post('/admin/documents/{id}/reject', [DocumentReviewController::class, 'rejectDocument'])->name('admin.documents.reject');
+        Route::post('/admin/documents/{id}/request-resubmission', [DocumentReviewController::class, 'requestResubmission'])->name('admin.documents.request-resubmission');
+        Route::get('/admin/get-admins', [DocumentReviewController::class, 'getAdmins'])->name('admin.get-admins');
+    });
+    // ---------------- Student ----------------
+    Route::middleware(['auth', NoBackHistory::class, IsStudent::class])->group(function () {
+        Route::get('/student/dashboard', fn () => view('student.dashboard'))->name('student.dashboard');
+        Route::get('/student/settings', [SettingsController::class, 'viewSettings'])->name('student.settings');
+        Route::post('/student/settings/update-profile-picture', [SettingsController::class, 'updateProfilePicture'])->name('settings.update-profile-picture');
+        Route::get('/student/submit-documents', [DocumentController::class, 'create'])->name('student.submit-documents');
+        Route::post('/submit-document', [DocumentController::class, 'store'])->name('submit.document');
+        Route::get('/student/documentArchive', fn () => view('student.documentArchive'))->name('student.documentArchive');
+        Route::get('/student/studentTracker', [StudentTrackerController::class, 'viewStudentTracker'])->name('student.studentTracker');
+        Route::get('/student/document/preview/{id}', [StudentDocumentController::class, 'preview'])->name('student.documentPreview');
+});
+
+Route::middleware(['auth', \App\Http\Middleware\NoBackHistory::class])->group(function () {
+
+    // ---------------- Shared Settings ----------------
+    Route::post('/settings/change-password', [SettingsController::class, 'changePassword'])->name('settings.change-password');
+
+    // ---------------- Shared Routes ----------------
+    Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
+    Route::get('/dashboard', fn () => view('student.dashboard'))->name('dashboard');
+
+    // Calendar
     Route::get('/calendar', [EventController::class, 'index'])->name('calendar.index');
     Route::post('/events', [EventController::class, 'store'])->name('events.store');
     Route::put('/events/{event}', [EventController::class, 'update'])->name('events.update');
     Route::delete('/events/{event}', [EventController::class, 'destroy'])->name('events.destroy');
 
-    // User routes
+    // User
     Route::post('/users', [UserController::class, 'store'])->name('users.store');
     Route::put('/users/{id}', [UserController::class, 'update'])->name('users.update');
     Route::post('/users/{id}', [UserController::class, 'update']);
-
-    // Settings routes
-    Route::get('student/settings', [SettingsController::class, 'viewSettings'])->name('student.settings');
-    Route::post('student/settings/update-profile-picture', [SettingsController::class, 'updateProfilePicture'])->name('settings.update-profile-picture');
-    Route::post('/settings/change-password', [SettingsController::class, 'changePassword'])->name('settings.change-password');
-
-    Route::get('admin/settings', [SettingsController::class, 'viewAdminSettings'])->name('admin.settings');
-    Route::post('admin/settings/update-profile-picture', [SettingsController::class, 'updateProfilePicture'])->name('settings.update-profile-picture');
-    Route::post('/settings/change-password', [SettingsController::class, 'changePassword'])->name('settings.change-password');
-
-    Route::get('/super-admin/dashboard', fn() => view('super-admin.dashboard'))->name('super-admin.dashboard');
     Route::post('/check-email', [UserController::class, 'checkEmail'])->name('check.email');
     Route::get('/check-roles', [UserController::class, 'checkRoles'])->name('check.roles');
-
-    Route::get('/admin/documentReview', [DocumentReviewController::class, 'index'])->name('admin.documentReview');
-
-    Route::get('/super-admin/deactivated-accounts', function () {
-        return view('super-admin.deactPage');
-    })->name('deactivated.accounts');
-
-    Route::get('/super-admin/deactivated-accounts', [UserController::class, 'deactivatedUsers'])
-    ->name('deactivated.accounts');
-
-    Route::get('/admin/review', function () {
-        return view('admin.review');
-    })->name('admin.review');
-
-    Route::get('/super-admin/dashboard', [SuperAdminController::class, 'showDashboard'])->name('super-admin.dashboard');
-    Route::post('/users', [App\Http\Controllers\UserController::class, 'store'])->name('users.store');
-
-    // Submit Document Route
-    Route::get('/student/submit-documents', [DocumentController::class, 'create'])->name('student.submit-documents');
-
-    Route::post('/submit-document', [DocumentController::class, 'store'])->name('submit.document');
-
-    Route::post('/super-admin/deactivate-user', [SuperAdminController::class, 'deactivateUser'])->name('super-admin.deactivate-user');
-
-    Route::post('/super-admin/reactivate-user/{user}', [UserController::class, 'reactivateUser'])->name('reactivate.user');
-    // Dashboard Route
-    Route::get('/dashboard', function () {
-        return view('student.dashboard');
-    })->name('dashboard');
-
-    Route::get('/admin/documentArchive', function () {
-        return view('admin.documentArchive');
-    })->name('admin.documentArchive');
-
-    Route::get('/student/documentArchive', function () {
-        return view('student.documentArchive');
-    })->name('student.documentArchive');
-    // Route for the document preview page (admin)
-    Route::get('/document/preview/{id}', [AdminDocumentController::class, 'preview'])->name('admin.documentPreview');
-
-    Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 });
 
-// Fetching and displaying and storing comments
+// ----------------------------------------
+// Comments (Shared)
+// ----------------------------------------
 Route::post('/comments', [CommentController::class, 'store'])->name('comments.store');
 Route::get('/comments/{documentId}', [CommentController::class, 'getComments'])->name('comments.get');
 
+// ----------------------------------------
+// Notifications (Shared)
+// ----------------------------------------
+Route::get('/notification', fn () => view('components.general-components.notification'));
+Route::get('/notifications', fn () => view('notifications'))->name('notifications');
+Route::post('/notifications/{notification}/mark-as-read', [NotificationController::class, 'markAsRead'])->middleware('auth');
 
-Route::middleware(['auth'])->group(function () {
-    // Fetching and displaying documents for admin
-    Route::get('/admin/documents', [DocumentReviewController::class, 'index'])->name('admin.documents');
-    Route::get('/admin/documents/{id}/details', [DocumentReviewController::class, 'getDetails'])->name('admin.documents.details');
-    Route::post('/admin/documents/{id}/mark-as-opened', [DocumentReviewController::class, 'markAsOpened'])->name('admin.documents.mark-as-opened');
-
-    // Document approval routes
-    Route::post('/admin/documents/{id}/approve', [DocumentReviewController::class, 'approveDocument'])->name('admin.documents.approve');
-    Route::post('/admin/documents/{id}/forward', [DocumentReviewController::class, 'forwardDocument'])->name('admin.documents.forward');
-    Route::get('/admin/get-admins', [DocumentReviewController::class, 'getAdmins'])->name('admin.get-admins');
-
-    // Document rejection routes
-    Route::post('/admin/documents/{id}/reject', [DocumentReviewController::class, 'rejectDocument'])->name('admin.documents.reject');
-    Route::post('/admin/documents/{id}/request-resubmission', [DocumentReviewController::class, 'requestResubmission'])->name('admin.documents.request-resubmission');
-});
-
-// Route for the student tracker page
-Route::get('/student/studentTracker', [StudentTrackerController::class, 'viewStudentTracker'])->name('student.studentTracker');
-
-Route::get('/notifications', function () {
-    return view('notifications');
-})->name('notifications');
-
-
-// CHANGE THIS //
-// Route::get('/', function () {
-//     return view('admin.documentArchive');
-// });
-
-
+// ----------------------------------------
+// Calendar IndexTwo (Shared)
+// ----------------------------------------
 Route::get('/calendar/indexTwo', [IndexTwoController::class, 'viewIndexTwo'])->name('calendar.indexTwo');
 
-// Route for the document preview page (admin)
-Route::get('/document/preview/{id}', [AdminDocumentController::class, 'preview'])->name('admin.documentPreview');
+// ----------------------------------------
+        // Document Viewing (Shared)
+        // ----------------------------------------
+        Route::get('/documents/{filename}', function ($filename) {
+            $path = public_path('documents/' . $filename);
+            if (!file_exists($path)) abort(404);
 
-// Route for the document preview page (student)
-Route::get('/student/document/preview/{id}', [StudentDocumentController::class, 'preview'])
-    ->name('student.documentPreview');
+            $mimeType = File::mimeType($path);
+            if ($mimeType === 'application/pdf') {
+                return Response::make(file_get_contents($path), 200, [
+                    'Content-Type' => $mimeType,
+                    'Content-Disposition' => 'inline; filename="' . $filename . '"'
+                ]);
+            }
 
-// Document viewing
-Route::get('/test-pdf', function() {
-    return response()->file(public_path('documents/test/sample.pdf'));
-});
+            return response()->file($path);
+        })->name('document.view')->middleware('auth');
 
-// Fetching and displaying and storing comments
-Route::post('/comments', [CommentController::class, 'store'])->name('comments.store');
-Route::get('/comments/{documentId}', [CommentController::class, 'getComments'])->name('comments.get');
+        Route::get('/test-pdf', fn () => response()->file(public_path('documents/test/sample.pdf')));
 
-// Route for the document preview page (student)
-Route::get('/student/document/preview/{id}', [StudentDocumentController::class, 'preview'])
-    ->name('student.documentPreview');
-
-// Document viewing
-Route::get('/documents/{filename}', function ($filename) {
-    $path = public_path('documents/' . $filename);
-
-    if (!file_exists($path)) {
-        abort(404);
-    }
-
-    $mimeType = File::mimeType($path);
-
-    // Force inline display for PDFs
-    if ($mimeType === 'application/pdf') {
-        return Response::make(file_get_contents($path), 200, [
-            'Content-Type' => $mimeType,
-            'Content-Disposition' => 'inline; filename="' . $filename . '"'
-        ]);
-    }
-
-    // For images and other files
-    return response()->file($path);
-})->name('document.view')->middleware('auth');
-
+// ----------------------------------------
+// Records (Shared)
+// ----------------------------------------
 Route::get('/records/{id}', [StudentTrackerController::class, 'show'])->name('records.show');
-Route::post('/notifications/{notification}/mark-as-read', [\App\Http\Controllers\NotificationController::class, 'markAsRead'])->middleware('auth');


### PR DESCRIPTION
This pull request addresses G3A-128 by implementing the following:
- Users are restricted from accessing any pages that belong to other roles. Even if a user manually inputs a URL for a page outside their assigned role, access will be denied or redirected appropriately.
- After logging in, using the browser’s back button will no longer return the user to the login page. Instead, it redirects them to their designated dashboard, ensuring a secure and seamless experience.