### PR TITLE
G3A-129 FIX: Update Forgot Password Validation

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,18 +6,18 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
-
+use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-
+    use HasFactory, Notifiable;
 
     public function notifications()
     {
         return $this->hasMany(\App\Models\Notification::class, 'user_id');
     }
-   
+
 
     public function sendPasswordResetNotification($token)
     {
@@ -81,7 +81,7 @@ class User extends Authenticatable
     {
         return $this->hasMany(SubmittedDocument::class, 'received_by');
     }
-    
+
     /**
      * Get the document reviews done by this user
      */

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -163,6 +163,10 @@
 
             // Handle email length warning
             emailInput.addEventListener('input', function () {
+                // Prevent spaces in email
+                emailInput.addEventListener('keydown', function (e) {
+                    if (e.key === ' ') e.preventDefault();
+                });
                 const email = emailInput.value.trim();
                 const isTooLong = email.length > 50;
 

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -280,6 +280,11 @@ if ($role === 'super admin') {
             confirmPasswordLabel.classList.add('ring-3', '!ring-red-600');
         }
 
+        document.querySelector('form').addEventListener('submit', function (e) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'Please wait...';
+    });
+
     </script>
 </body>
 </html>


### PR DESCRIPTION
This G3A-129 PR includes the following fixes and improvements:

- Fix Notifiable in User Model
   - Re-added Notifiable to the User model (use HasFactory, Notifiable;).
   - This was required for the Forgot Password feature to work properly via notifications.
- Forgot Password: Reject Emails with Spaces
   - Implemented validation to reject email addresses that contain spaces.
   - Ensures only valid, properly formatted emails are submitted.
- Reset Password: Prevent Multiple Submissions
   - Disabled the "Reset Password" button immediately after click.
   - Prevents accidental double submissions and improves UX.