### PR TITLE
G3A-141 FIX: Update Forgot Pass Email Expiry Text

### DIFF
--- a/resources/views/emails/custom-reset-password.blade.php
+++ b/resources/views/emails/custom-reset-password.blade.php
@@ -107,7 +107,7 @@
             </p>
             <a class="reset__link" href="{{ $url }}">Reset Password</a>
             <p class="last-p">
-                This password reset link will expire in 60 minutes. If you did not request a password reset, no further action is required.
+                This password reset link will expire in 15 minutes. If you did not request a password reset, no further action is required.
             </p>
         </div>
         <hr>


### PR DESCRIPTION
This PR updates the text content in the forgot password email to reflect a 15-minute expiration instead of 60 minutes.