### PR TITLE
FIX NS9-113 : Directly Navigates to the Document for Student and AUTO Mark as Done when a Notif is clicked

### DIFF
--- a/app/Listeners/SendDocumentStatusNotification.php
+++ b/app/Listeners/SendDocumentStatusNotification.php
@@ -29,7 +29,7 @@ class SendDocumentStatusNotification
 
         $status = $doc->status; // 'approved' or 'rejected'
         $title = 'Document ' . ucfirst($status);
-        $message = "Your document \"{$doc->title}\" (ID: {$doc->id}) was {$status}.";
+        $message = "Your document for subject \"{$doc->subject}\" (Type: {$doc->type}, ID: {$doc->id}) was {$status}.";
 
         try {
             Notification::create([
@@ -37,7 +37,7 @@ class SendDocumentStatusNotification
                 'message' => $message,
                 'user_id' => $student->id,
                 'is_read' => false,
-                'url'     => "/student/documents/{$doc->id}",
+                'url'     => route('records.show', ['id' => $doc->id]),
             ]);
             Log::info("Student notification created for user_id={$student->id}");
         } catch (\Exception $ex) {

--- a/resources/views/components/general-components/notification.blade.php
+++ b/resources/views/components/general-components/notification.blade.php
@@ -118,7 +118,7 @@
             <div id="unreadNotifications" class="hidden">
                 @if($unreadNotifications->isEmpty())
                  
-                    <div class="flex flex-col items-center justify-center h-full text-center text-gray-500">
+                    <div class="flex flex-col items-center justify-center h-full text-center text-gray-500 w-full" style="min-height: 16rem;">
                          <svg class="w-16 h-16 text-gray-300 mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
                         </svg>
@@ -399,8 +399,20 @@
             }
         });
 
-
-
+        // Add click event to notification links to mark as read
+        document.querySelectorAll('[data-notification-id]').forEach(link => {
+            link.addEventListener('click', function(e) {
+                const notificationId = this.getAttribute('data-notification-id');
+                fetch(`/notifications/${notificationId}/mark-as-read`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                    }
+                });
+                // Let the link continue to its href
+            });
+        });
 
     });
 </script>


### PR DESCRIPTION
ADDED:
* Updated the notification message in `SendDocumentStatusNotification.php` to include the document's subject and type for better context. Additionally, replaced the hardcoded URL with a named route for improved maintainability. 
* Adjusted the layout and styling of the empty notifications state in `notification.blade.php` to ensure better alignment and 
* Added a JavaScript feature in `notification.blade.php` to mark notifications as read when their links are clicked.