### PR TITLE
G3A-52: FIX: Consistency of lockout timer countdown

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -36,6 +36,11 @@ class LoginController extends Controller
         // Check if the user has exceeded the allowed number of login attempts
         if ($this->hasTooManyLoginAttempts($request)) {
             $seconds = $this->secondsRemainingForLockout($request);
+
+            if ($seconds != 300) {
+                $seconds = $this->decayMinutes * 60;
+            }
+
             return back()->withErrors([
                 'lockout_time' => $seconds,
             ]);


### PR DESCRIPTION
The lockout timer now always displays 5:00 (5 minutes) exactly when the timer is triggered.