### PR TITLE
G3A-148 FIX: Reset lockout red border on login input when role switch

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -161,6 +161,8 @@
             }
 
             if (roleInput.value === currentRole) {
+                emailLabel.classList.add('ring-3', '!ring-red-600');
+                passwordLabel.classList.add('ring-3', '!ring-red-600');
                 lockoutMsg.style.display = '';
 
                 if (!isLockoutExpiredMessage) {
@@ -168,6 +170,8 @@
                     passwordInput.disabled = true;
                 }
             } else {
+                emailLabel.classList.remove('ring-3', '!ring-red-600');
+                passwordLabel.classList.remove('ring-3', '!ring-red-600');
                 lockoutMsg.style.display = 'none';
                 emailInput.disabled = false;
                 passwordInput.disabled = false;
@@ -688,7 +692,6 @@
         validateInputs();
     });
     </script>
-
     </body>
 </body>
 </html>


### PR DESCRIPTION
This PR addresses the issue where the red border indicating a lockout error remained visible on login inputs when switching between user roles (e.g., Student to Admin or vice versa). The fix ensures the lockout error styling is cleared upon role change, providing a clean and accurate login interface for each role.