### PR TITLE
G3A-159 FIX: Implement tracking of latest password change datetime

### DIFF
--- a/app/Http/Controllers/Auth/AdminPasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/AdminPasswordResetLinkController.php
@@ -97,6 +97,7 @@ class AdminPasswordResetLinkController extends Controller
         }
 
         $user->password = bcrypt($request->password);
+        $user->password_changed_at = now();
         $user->save();
 
         DB::table('password_reset_tokens')->where('email', $request->email)->delete();

--- a/app/Http/Controllers/Auth/StudentPasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/StudentPasswordResetLinkController.php
@@ -89,6 +89,7 @@ class StudentPasswordResetLinkController extends Controller
         }
 
         $user->password = bcrypt($request->password);
+        $user->password_changed_at = now();
         $user->save();
 
         DB::table('password_reset_tokens')->where('email', $request->email)->delete();

--- a/database/migrations/2025_05_27_140441_change_password_changed_at_type_to_datetime.php
+++ b/database/migrations/2025_05_27_140441_change_password_changed_at_type_to_datetime.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->datetime('password_changed_at')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('password_changed_at')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
This PR addresses the need to track when a user's password was last updated. A new password_changed_at column is added to the users table, and logic is implemented to update this only when the password is changed.