### PR TITLE
G3A-160 FIX: Add Expired Token Modal for Reset Password Page

### DIFF
--- a/app/Http/Controllers/Auth/AdminPasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/AdminPasswordResetLinkController.php
@@ -47,7 +47,29 @@ class AdminPasswordResetLinkController extends Controller
 
     public function edit($token)
     {
-        return view('auth.admin-reset-password', ['token' => $token]);
+       $email = request()->query('email');
+        $tokenRecord = null;
+
+        if ($email) {
+            $tokenRecord = DB::table('password_reset_tokens')
+                ->where('email', $email)
+                ->first();
+        }
+
+        $tokenExpired = false;
+        if (
+            !$tokenRecord ||
+            !Hash::check($token, $tokenRecord->token) ||
+            \Carbon\Carbon::parse($tokenRecord->created_at)->addMinutes(15)->isPast()
+        ) {
+            $tokenExpired = true;
+        }
+
+        return view('auth.admin-reset-password', [
+            'token' => $token,
+            'tokenExpired' => $tokenExpired,
+            'email' => $email,
+        ]);
     }
 
     public function update(Request $request)

--- a/app/Http/Controllers/Auth/StudentPasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/StudentPasswordResetLinkController.php
@@ -32,7 +32,7 @@ class StudentPasswordResetLinkController extends Controller
             ->first();
 
         if (!$user) {
-            return back()->withErrors(['email' => 'We can\'t find a student with that email address.']);
+            return back()->withErrors(['email' => 'We can\'t find a student organization with that email address.']);
         }
 
         $status = Password::sendResetLink($request->only('email'));
@@ -44,7 +44,29 @@ class StudentPasswordResetLinkController extends Controller
 
     public function edit($token)
     {
-        return view('auth.student-reset-password', ['token' => $token]);
+        $email = request()->query('email');
+        $tokenRecord = null;
+
+        if ($email) {
+            $tokenRecord = DB::table('password_reset_tokens')
+                ->where('email', $email)
+                ->first();
+        }
+
+        $tokenExpired = false;
+        if (
+            !$tokenRecord ||
+            !Hash::check($token, $tokenRecord->token) ||
+            \Carbon\Carbon::parse($tokenRecord->created_at)->addMinutes(15)->isPast()
+        ) {
+            $tokenExpired = true;
+        }
+
+        return view('auth.student-reset-password', [
+            'token' => $token,
+            'tokenExpired' => $tokenExpired,
+            'email' => $email,
+        ]);
     }
 
     public function update(Request $request)

--- a/resources/views/auth/admin-reset-password.blade.php
+++ b/resources/views/auth/admin-reset-password.blade.php
@@ -88,6 +88,23 @@
 
 @include('loading');
 <body id="box" class="min-h-screen flex items-center justify-center font-['Manrope'] font-bold bg-gradient-to-r from-[var(--login-color-left)] to-[var(--login-color-right)]  md:backdrop-blur-xs ">
+    {{-- Modal for expired token --}}
+    @if (!empty($tokenExpired) && $tokenExpired)
+        <div id="expiredModal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+            <div class="bg-white rounded-lg shadow-lg p-8 max-w-sm w-full text-center">
+                <h2 class="text-xl font-bold mb-4 text-red-600">Token Expired</h2>
+                <p class="mb-6">Your password reset link has expired or is invalid. Please request a new one.</p>
+                <a href="{{ route('admin.login.form') }}" class="inline-block px-6 py-2 bg-[var(--secondary-color)] text-white rounded-full font-bold hover:bg-[var(--primary-color)] transition">Back to Login</a>
+            </div>
+        </div>
+        <script>
+            // Prevent form interaction when modal is open
+            document.addEventListener('DOMContentLoaded', function() {
+                document.querySelector('form').style.filter = 'blur(2px)';
+                document.querySelector('form').style.pointerEvents = 'none';
+            });
+        </script>
+    @endif
     <div class="p-5 w-full">
         <div class="w-full mx-auto py-10 rounded-[40px] max-md:max-w-[520px] max-md:bg-white/60 max-md:shadow-md">
             <div class="flex justify-center pb-4">

--- a/resources/views/auth/student-reset-password.blade.php
+++ b/resources/views/auth/student-reset-password.blade.php
@@ -91,6 +91,23 @@
 
 @include('loading');
 <body id="box" class="min-h-screen flex items-center justify-center font-['Manrope'] font-bold bg-gradient-to-r from-[var(--login-color-left)] to-[var(--login-color-right)]  md:backdrop-blur-xs ">
+    {{-- Modal for expired token --}}
+    @if (!empty($tokenExpired) && $tokenExpired)
+        <div id="expiredModal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+            <div class="bg-white rounded-lg shadow-lg p-8 max-w-sm w-full text-center">
+                <h2 class="text-xl font-bold mb-4 text-red-600">Token Expired</h2>
+                <p class="mb-6">Your password reset link has expired or is invalid. Please request a new one.</p>
+                <a href="{{ route('student.login.form') }}" class="inline-block px-6 py-2 bg-[var(--secondary-color)] text-white rounded-full font-bold hover:bg-[var(--primary-color)] transition">Back to Login</a>
+            </div>
+        </div>
+        <script>
+            // Prevent form interaction when modal is open
+            document.addEventListener('DOMContentLoaded', function() {
+                document.querySelector('form').style.filter = 'blur(2px)';
+                document.querySelector('form').style.pointerEvents = 'none';
+            });
+        </script>
+    @endif
     <div class="p-5 w-full">
         <div class="w-full mx-auto py-10 rounded-[40px] max-md:max-w-[520px] max-md:bg-white/60 max-md:shadow-md">
             <div class="flex justify-center pb-4">


### PR DESCRIPTION
This PR introduces a modal that is displayed when a user attempts to reset their password using an expired token.

Changes made:
- Added a modal component to inform users that the reset token has expired.

