### PR TITLE
DBA1-147 FIX: Entered data clears after modal reopens

### DIFF
--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1107,8 +1107,30 @@
             document.getElementById('postAnnouncementModal').classList.remove('hidden');
         }
         function closePostAnnouncementModal() {
-            document.getElementById('postAnnouncementModal').classList.add('hidden');
-        }
+            // Get the form element
+        const announcementForm = document.getElementById('announcementForm');
+        
+        // Reset all form fields
+        announcementForm.reset();
+        
+        // Clear any displayed error messages
+        document.getElementById('titleError').style.display = 'none';
+        document.getElementById('contentError').style.display = 'none';
+        
+        // Reset specific UI elements
+        
+        // Hide schedule fields if they were showing
+        document.getElementById('scheduleFields').classList.add('hidden');
+        
+        // Hide custom audience dropdown if it was showing
+        document.getElementById('customAudienceDropdown').classList.add('hidden');
+        
+        // Set audience radio back to 'all' (default)
+        document.getElementById('audienceAll').checked = true;
+        
+        // Hide the modal
+        document.getElementById('postAnnouncementModal').classList.add('hidden');
+    }
 
         // Schedule toggle
         document.getElementById('scheduleCheckbox').addEventListener('change', function() {

--- a/resources/views/super-admin/dashboard.blade.php
+++ b/resources/views/super-admin/dashboard.blade.php
@@ -1407,8 +1407,30 @@
         }
 
         function closePostAnnouncementModal() {
-            document.getElementById('postAnnouncementModal').classList.add('hidden');
-        }
+                // Get the form element
+        const announcementForm = document.getElementById('announcementForm');
+        
+        // Reset all form fields
+        announcementForm.reset();
+        
+        // Clear any displayed error messages
+        document.getElementById('titleError').style.display = 'none';
+        document.getElementById('contentError').style.display = 'none';
+        
+        // Reset specific UI elements
+        
+        // Hide schedule fields if they were showing
+        document.getElementById('scheduleFields').classList.add('hidden');
+        
+        // Hide custom audience dropdown if it was showing
+        document.getElementById('customAudienceDropdown').classList.add('hidden');
+        
+        // Set audience radio back to 'all' (default)
+        document.getElementById('audienceAll').checked = true;
+        
+        // Hide the modal
+        document.getElementById('postAnnouncementModal').classList.add('hidden');
+    }
 
         // Schedule toggle
         document.getElementById('scheduleCheckbox').addEventListener('change', function() {


### PR DESCRIPTION
The entered data in posting the announcement is now not retaining or saving when the modal reopens.